### PR TITLE
Added rake support with two tasks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,9 @@ gem "jekyll", "~> 3.6.0"
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem "minima", "~> 2.0"
 
+# Manage tasks
+gem "rake"
+
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.
 # gem "github-pages", group: :jekyll_plugins
@@ -24,4 +27,3 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,6 +34,7 @@ GEM
     pathutil (0.16.0)
       forwardable-extended (~> 2.6)
     public_suffix (3.0.1)
+    rake (12.3.0)
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
@@ -52,6 +53,7 @@ DEPENDENCIES
   jekyll (~> 3.6.0)
   jekyll-feed (~> 0.6)
   minima (~> 2.0)
+  rake
   tzinfo-data
 
 BUNDLED WITH

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,9 @@
+task default: %w[serve]
+
+task :serve do
+  system("jekyll serve")
+end
+
+task :update_readme do
+  system("cp README.md _includes/README.md")
+end

--- a/_includes/README.md
+++ b/_includes/README.md
@@ -1,1 +1,21 @@
-../README.md
+# EPFL Dojo website
+A static website for informations about EPFL dojos. Available here: <https://epfl-dojo.github.io/>.
+
+## Contributing
+Please be sure to make a PR if you want to contribute.
+
+## How to sign the charter
+Attendees of the EPFL dojo can commit themself by signing the EPFL Dojo charter.
+To do so, please open a PR on the file CHARTER.md:
+* Add your github username (alphabetical order) + the date (ISO8601 format);
+* Add that you have read and that you agree to commit to the charter;
+* Create your Pull Request on the main repository.
+
+## Development
+First you have to understand what is Jekyll and how it works. A simple `git clone ...`
+wouldn't be enough to run the site locally. You have to setup [jekyll](https://jekyllrb.com/docs/installation/) first.
+
+* install [jekyll](https://jekyllrb.com/docs/installation/) (e.g. `sudo apt install jekyll`, `bundle install`)
+* checkout the repository
+* run (`jekyll serve`)
+* go to the listed URL (e.g. http://localhost:4000)


### PR DESCRIPTION
* `rake` or `rake serve` to call jekyll serve
* `rake update_readme` to copy the README.md into _includes/
Github pages do not accept symlinks. Maybe we should integrate the update_readme task into a continuous integration engine so the README visible inside the website is always up-to-date.